### PR TITLE
Support for PiCamera2, zmq server for integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,13 @@ if(NOT GPIOD_LIBRARY)
 endif()
 
 
+
 #executable
 add_executable(control_program code/main.cpp code/gnss.cpp code/web_page.h code/LivoxClient.cpp code/gpios.cpp code/FileSystemClient.cpp code/save_laz.cpp ${PISTACHE_SRC}
-        code/utils/TimeStampReceiver.cpp)
+        code/utils/TimeStampReceiver.cpp code/publisher.cpp)
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-target_link_libraries(control_program pthread livox_lidar_sdk_static pistache atomic laszip ${LIBSERIAL_LIBRARY} minea gpiod)
+
+target_link_libraries(control_program pthread livox_lidar_sdk_static pistache atomic laszip ${LIBSERIAL_LIBRARY} minea gpiod zmq)
 
 
 add_executable(led_demo code/led_demo.cpp code/gpios.cpp)
@@ -81,3 +83,4 @@ target_link_libraries(fake_pps ${LIBSERIAL_LIBRARY} gpiod pthread)
 add_executable(button_demo code/button_demo.cpp code/gpios.cpp)
 set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS}")
 target_link_libraries(button_demo gpiod pthread)
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The software can run other distros (e.g. Ubuntu) but it is not tested and mainta
 ```bash
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install build-essential cmake git rapidjson-dev debhelper build-essential ntfs-3g libserial-dev libgpiod-dev
+sudo apt-get install build-essential cmake git rapidjson-dev debhelper build-essential ntfs-3g libserial-dev libgpiod-dev libzmq3-dev
 ```
 
 

--- a/code/hardware_config/mandeye-standard-rpi5.h
+++ b/code/hardware_config/mandeye-standard-rpi5.h
@@ -80,13 +80,13 @@ constexpr GPIO::GPIO_PULL GetPULL([[maybe_unused]] BUTTON btn)
 
 [[maybe_unused]] inline const std::string GetGNSSPort()
 {
-	return "/dev/S0";
+	return "/dev/ttyAMA0";
 };
 
 
 [[maybe_unused]] inline const LibSerial::BaudRate GetGNSSBaudrate()
 {
-	return LibSerial::BaudRate::BAUD_38400;
+	return LibSerial::BaudRate::BAUD_115200;
 };
 
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -18,7 +18,7 @@
 #define MANDEYE_LIVOX_LISTEN_IP "192.168.1.5"
 #define MANDEYE_REPO "/media/usb/"
 #define MANDEYE_GPIO_SIM false
-#define SERVER_PORT 8004
+#define SERVER_PORT 8003
 
 
 namespace utils

--- a/code/publisher.cpp
+++ b/code/publisher.cpp
@@ -7,6 +7,7 @@ Publisher::Publisher()
 	, m_publisher(m_context, ZMQ_PUB)
 {
 	m_publisher.bind("tcp://*:5556");
+	m_publisher.setsockopt(ZMQ_CONFLATE, 1); // Keep only the latest task
 	m_thread = std::thread(&Publisher::worker, this);
 }
 Publisher::~Publisher()
@@ -27,19 +28,20 @@ void Publisher::worker()
 {
 	while(m_running)
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		std::this_thread::sleep_for(std::chrono::milliseconds(25));
 		const double time = GetTimeStamp();
 		if(std::floor(time) != std::floor(m_lastTime))
 		{
 			nlohmann::json data;
 			{
 				std::unique_lock<std::mutex> lock(m_mutex);
-				data["time"] = time;
+				data["time"] = static_cast<uint64_t>(time*1e9);
 				data["stopScanDirectory"] = m_stopScanDirectory;
 				data["continousScanDirectory"] = m_continousScanDirectory;
 				data["mode"] = m_mode;
 			}
 			publish(data);
+			std::this_thread::sleep_for(std::chrono::milliseconds(900));
 		}
 		m_lastTime = time;
 	}

--- a/code/publisher.cpp
+++ b/code/publisher.cpp
@@ -1,0 +1,60 @@
+#include "publisher.h"
+
+namespace mandeye
+{
+Publisher::Publisher()
+	: m_context(1)
+	, m_publisher(m_context, ZMQ_PUB)
+{
+	m_publisher.bind("tcp://*:5556");
+	m_thread = std::thread(&Publisher::worker, this);
+}
+Publisher::~Publisher()
+{
+	m_running = false;
+	m_thread.join();
+	m_publisher.close();
+}
+
+void Publisher::publish(const nlohmann::json& data)
+{
+	auto dataMessage = data.dump();
+	zmq::message_t message(dataMessage.c_str(), dataMessage.size());
+	m_publisher.send(message, zmq::send_flags::none);
+}
+
+void Publisher::worker()
+{
+	while(m_running)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		const double time = GetTimeStamp();
+		if(std::floor(time) != std::floor(m_lastTime))
+		{
+			nlohmann::json data;
+			{
+				std::unique_lock<std::mutex> lock(m_mutex);
+				data["time"] = time;
+				data["stopScanDirectory"] = m_stopScanDirectory;
+				data["continousScanDirectory"] = m_continousScanDirectory;
+				data["mode"] = m_mode;
+			}
+			publish(data);
+		}
+		m_lastTime = time;
+	}
+}
+
+void Publisher::SetWorkingDirectory(const std::string& stopScanDirectory, const std::string& continousScanDirectory)
+{
+	std::unique_lock<std::mutex> lock(m_mutex);
+	m_stopScanDirectory = stopScanDirectory;
+	m_continousScanDirectory = continousScanDirectory;
+}
+void Publisher::SetMode(const std::string& mode)
+{
+	std::unique_lock<std::mutex> lock(m_mutex);
+	m_mode = mode;
+}
+
+} // namespace mandeye

--- a/code/publisher.h
+++ b/code/publisher.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <json.hpp>
+#include <zmq.hpp>
+#include "utils/TimeStampReceiver.h"
+#include <thread>
+#include <atomic>
+#include <mutex>
+namespace mandeye
+{
+class Publisher : public mandeye_utils::TimeStampReceiver
+{
+public:
+	std::string_view ContinuesMode = "ContinuesMode";
+	std::string_view StopScanMode = "ChunkedMode";
+	Publisher();
+	~Publisher();
+	Publisher(const Publisher&) = delete;
+	Publisher& operator=(const Publisher&) = delete;
+	void publish(const nlohmann::json& data);
+	void SetWorkingDirectory(const std::string& stopScanDirectory, const std::string& continousScanDirectory);
+	void SetMode(const std::string& mode);
+private:
+	void worker();
+	std::atomic<bool> m_running{true};
+	std::string m_continousScanDirectory;
+	std::string m_stopScanDirectory;
+	std::string m_mode;
+	zmq::context_t m_context;
+	zmq::socket_t m_publisher;
+	std::thread m_thread;
+	std::mutex m_mutex;
+	double m_lastTime=0;
+};
+}

--- a/extras/picamera2/README.md
+++ b/extras/picamera2/README.md
@@ -45,3 +45,16 @@ You can check status of the service with:
 ```bash
 sudo systemctl status mandeye_picamera.service
 ```
+
+## Config
+The camera can be configured in runtime loading file from pendrive.
+Place a file `/media/usb/mandeye/mandeye_config.json`:
+```json
+{
+    "picamera":
+    {
+        "ExposureValue": -10,
+        "AnalogueGain": 22
+    }    
+}
+```

--- a/extras/picamera2/README.md
+++ b/extras/picamera2/README.md
@@ -1,0 +1,47 @@
+# Picamera2 driver
+
+
+## Description
+The driver that connects to the camera and listens for commands from the controller.
+
+## Installation
+
+Prerequisites:
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install python3-zmq 
+```
+
+Service installation:
+Create a file `/usr/lib/systemd/system/mandeye_picamera.service` with content.
+Note that you need to adjust your user's name:
+
+```bash
+[Unit]
+Description=Mandeye_Picamera2
+After=multi-user.target
+
+[Service]
+User=mandeye
+StandardOutput=null
+StandardError=null
+ExecStartPre=/bin/sleep 20
+ExecStart=python3 /home/robot/mandeye_controller/build/extras/camera.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+```
+
+Next reload daemons, enable and start the service`
+```
+sudo systemctl daemon-reload
+sudo systemctl enable mandeye_picamera.service
+sudo systemctl start mandeye_picamera.service
+```
+You can check status of the service with:
+```bash
+sudo systemctl status mandeye_picamera.service
+```

--- a/extras/picamera2/README.md
+++ b/extras/picamera2/README.md
@@ -27,7 +27,7 @@ User=mandeye
 StandardOutput=null
 StandardError=null
 ExecStartPre=/bin/sleep 20
-ExecStart=python3 /home/robot/mandeye_controller/build/extras/camera.py
+ExecStart=python3 /home/mandeye/mandeye_controller/extras/picamera2/camera.py 
 Restart=always
 
 [Install]

--- a/extras/picamera2/README.md
+++ b/extras/picamera2/README.md
@@ -10,7 +10,7 @@ Prerequisites:
 ```bash
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install python3-zmq 
+sudo apt-get install python3-zmq python3-systemmd
 ```
 
 Service installation:

--- a/extras/picamera2/camera.py
+++ b/extras/picamera2/camera.py
@@ -2,13 +2,57 @@
 import zmq
 import time
 import json
+import os
 from picamera2 import Picamera2
+
+
+def load_json_config(file_path):
+    """
+    Loads and parses the JSON configuration from the specified file.
+    :param file_path: Path to the JSON config file.
+    :return: A dictionary with the parsed configuration or an empty dictionary if invalid.
+    """
+    if not os.path.isfile(file_path):
+        print(f"Error: File '{file_path}' does not exist.")
+        return {}
+
+    try:
+        with open(file_path, "r") as file:
+            data = json.load(file)
+
+        if not isinstance(data, dict):
+            print("Error: Configuration file must contain a JSON object.")
+            return {}
+        if 'picamera' in data:
+            return data['picamera']
+        return {}
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error: Failed to read or parse the configuration file. {e}")
+        return {}
+
+def validate_and_apply_config(config):
+    """
+    Validates and applies a dynamic configuration to Picamera2.
+    :param picam: An instance of Picamera2.
+    :param config: A dictionary of configuration parameters.
+    """
+    # Validate and apply general settings dynamically
+    controls = picam2.camera_controls
+
+    for key, value in config.items():
+        try:
+            picam2.set_controls({key: value})
+        except Exception as e:
+            print(f"Error: Failed to apply parameter '{key}'. {e}")
+
 
 # Set up ZeroMQ context and subscriber socket
 context = zmq.Context()
 socket = context.socket(zmq.SUB)
 socket.connect("tcp://localhost:5556") 
 socket.setsockopt_string(zmq.SUBSCRIBE, "")
+socket.setsockopt(zmq.CONFLATE,1)
+
 
 # Initialize the Picamera2 camera
 picam2 = Picamera2()
@@ -19,7 +63,13 @@ picam2.configure(camera_config)
 #picam2.set_controls({"AeEnable": 0, "ExposureTime": 25000})  # Example: 5 ms exposure
 
 # automated exposue, set to small value
-picam2.set_controls({"ExposureValue": -4})
+picam2.set_controls({"ExposureValue": -6})
+users_config = load_json_config("/media/usb/mandeye_config.json")
+print ("User's config:")
+print ("===========================")
+print (users_config)
+print ("===========================")
+validate_and_apply_config(users_config)
 
 #
 #picam2.set_controls({"HdrMode":4});

--- a/extras/picamera2/camera.py
+++ b/extras/picamera2/camera.py
@@ -15,11 +15,25 @@ picam2 = Picamera2()
 camera_config = picam2.create_still_configuration(main={"size": picam2.sensor_resolution})
 picam2.configure(camera_config)
 
+#Manual exposure time
+#picam2.set_controls({"AeEnable": 0, "ExposureTime": 25000})  # Example: 5 ms exposure
+
+# automated exposue, set to small value
+picam2.set_controls({"ExposureValue": -4})
+
+#
+#picam2.set_controls({"HdrMode":4});
 
 picam2.start()
+# List the controls and their properties
 
+controls = picam2.camera_controls
+print("Available controls:")
+for control, info in controls.items():
+    print(f"{control}: {info}")
+    
 print("Subscriber connected and listening for messages...")
-
+picam2.capture_file("/tmp/test.jpg")
 # Receive messages in a loop and capture an image for each
 while True:
     # Wait for a message
@@ -29,7 +43,7 @@ while True:
         data = json.loads(message)
 
         mode = data['mode']
-        ts = data['time']
+        ts = int(data['time'])
         data_continous = data['continousScanDirectory']
         
   

--- a/extras/picamera2/camera.py
+++ b/extras/picamera2/camera.py
@@ -1,0 +1,41 @@
+
+import zmq
+import time
+import json
+from picamera2 import Picamera2
+
+# Set up ZeroMQ context and subscriber socket
+context = zmq.Context()
+socket = context.socket(zmq.SUB)
+socket.connect("tcp://localhost:5556") 
+socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+# Initialize the Picamera2 camera
+picam2 = Picamera2()
+camera_config = picam2.create_still_configuration(main={"size": picam2.sensor_resolution})
+picam2.configure(camera_config)
+
+
+picam2.start()
+
+print("Subscriber connected and listening for messages...")
+
+# Receive messages in a loop and capture an image for each
+while True:
+    # Wait for a message
+    message = socket.recv_string()
+    print("Received message:", message)
+    try:
+        data = json.loads(message)
+
+        mode = data['mode']
+        ts = data['time']
+        data_continous = data['continousScanDirectory']
+        
+  
+        if mode=='SCANNING':
+            filename = f"{data_continous}/photo_{ts}.jpg"
+            picam2.capture_file(filename)
+            print(f"Image saved as {filename}")
+    except Exception as X:
+        print (X)


### PR DESCRIPTION
The C++ core code gets a [ZMQ](https://zeromq.org/)  publisher. This publishes every second a message:
```
{"continousScanDirectory":"/media/usb/continousScanning_0001",
"mode":"IDLE",
"stopScanDirectory":"/media/usb/stopScans_0001",
"time":4100.0590543}
```
The Python camera driver receives it and takes images.
The driver can be installed as separated service.

The camera service can load config from usb ( mandeye_config.json) drive formated as:
```json
{
    "picamera":
    {
        "ExposureValue": -10,
        "AnalogueGain": 22
    }    
}
```
