### PR TITLE
Logging duration

### DIFF
--- a/3rd/Livox-SDK2/sdk_core/logger_handler/file_manager.h
+++ b/3rd/Livox-SDK2/sdk_core/logger_handler/file_manager.h
@@ -26,6 +26,7 @@
 #define LIVOX_FILE_MANAGER_
 
 #include <string>
+#include <cstdint>
 
 namespace livox {
 namespace lidar {

--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -81,7 +81,7 @@ nlohmann::json LivoxClient::produceStatus()
 	std::lock_guard<std::mutex> lcK2(m_bufferImuMutex);
 	data["LivoxLidarInfo"]["timestamp"] = m_timestamp;
 	if (m_sessionStart) {
-		data["LivoxLidarInfo"]["m_sessionStart"] = m_timestamp;
+		data["LivoxLidarInfo"]["m_sessionStart"] = *m_sessionStart;
 		data["LivoxLidarInfo"]["m_elapsed"] = m_elapsed;
 	}
 

--- a/code/LivoxClient.h
+++ b/code/LivoxClient.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include "utils/TimeStampProvider.h"
 #include <set>
+#include <optional>
 namespace mandeye
 {
 struct LivoxPoint
@@ -67,6 +68,8 @@ public:
 
 	// mandeye_utils::TimeStampProvider overrides ...
 	double getTimestamp() override;
+	double getSessionDuration() override;
+	double getSessionStart() override;
 
 	// periodically ask lidars for status
 	void testThread();
@@ -82,7 +85,10 @@ private:
 
 	std::mutex m_timestampMutex;
 	uint64_t m_timestamp;
+	uint64_t m_elapsed;
+	std::optional<uint64_t> m_sessionStart;
 
+	static void saveTimeStamp(LivoxClient *client, uint64_t timestamp);
 	//! Multilovx support
 	mutable std::mutex m_lidarInfoMutex;
 	std::unordered_map<uint32_t, uint64_t> m_recivedImuMsgs;

--- a/code/publisher.cpp
+++ b/code/publisher.cpp
@@ -30,12 +30,14 @@ void Publisher::worker()
 	{
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
 		const double time = GetTimeStamp();
+		const double elapsed = GetSessionDuration();
 		nlohmann::json data;
 		if(std::floor(time) != std::floor(m_lastTime))
 		{
 			// longer report
 			std::unique_lock<std::mutex> lock(m_mutex);
 			data["time"] = static_cast<uint64_t>(time*1e9);
+			data["dur"] = static_cast<uint64_t>(elapsed*1e9);
 			data["stopScanDirectory"] = m_stopScanDirectory;
 			data["continousScanDirectory"] = m_continousScanDirectory;
 			data["mode"] = m_mode;
@@ -46,6 +48,7 @@ void Publisher::worker()
 			// short report
 			std::unique_lock<std::mutex> lock(m_mutex);
 			data["time"] = static_cast<uint64_t>(time*1e9);
+			data["dur"] = static_cast<uint64_t>(elapsed*1e9);
 		}
 		publish(data);
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/code/utils/TimeStampProvider.h
+++ b/code/utils/TimeStampProvider.h
@@ -6,6 +6,11 @@ namespace mandeye_utils
 class TimeStampProvider
 {
 public:
+	//! Retrieve timestamp (e.g. UNIX timestamp in seconds)
 	virtual double getTimestamp() = 0;
+	//! Retrieve relative timestamp to start
+	virtual double getSessionDuration() = 0;
+
+	virtual double getSessionStart() = 0;
 };
 } // namespace mandeye_utils

--- a/code/utils/TimeStampReceiver.cpp
+++ b/code/utils/TimeStampReceiver.cpp
@@ -18,5 +18,18 @@ double TimeStampReceiver::GetTimeStamp()
 }
 
 
+double TimeStampReceiver::GetSessionDuration() {
+	if (m_timeStampProvider) {
+		return m_timeStampProvider->getSessionDuration();
+	}
+	return 0.0;
+}
+double TimeStampReceiver::GetSessionStart() {
+	if (m_timeStampProvider) {
+		return m_timeStampProvider->getSessionStart();
+	}
+	return 0.0;
+}
+
 }
 

--- a/code/utils/TimeStampReceiver.h
+++ b/code/utils/TimeStampReceiver.h
@@ -10,6 +10,9 @@ public:
 	void SetTimeStampProvider(std::shared_ptr<TimeStampProvider> timeStampProvider);
 	//! Returns the current timestamp
 	double GetTimeStamp();
+	double GetSessionDuration();
+	double GetSessionStart();
+
 protected:
 	//! The timestamp provider
 	std::shared_ptr<TimeStampProvider> m_timeStampProvider;


### PR DESCRIPTION
Log duration of next to timestamp in the log:
zmq data:
```
Received message: {"dur":75473280000,"time":2218933189740}
Received message: {"continousScanDirectory":"/media/usb/continousScanning_0013","dur":75598080000,"mode":"IDLE","stopScanDirectory":"/media/usb/stopScans_0013","time":2219057989740}
Received message: {"dur":75723360000,"time":2219183269740}
Received message: {"dur":75847680000,"time":2219307589740}

```