### PR TITLE
Start duration measurment on Continous Scan button

### DIFF
--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <thread>
 
-extern bool first;
-
 namespace mandeye
 {
 
@@ -236,23 +234,7 @@ void LivoxClient::saveTimeStamp(LivoxClient *client, uint64_t timestamp) {
 	std::lock_guard<std::mutex> lcK(client->m_timestampMutex);
 	client->m_timestamp = timestamp;
 	
-	static bool started = false;
-	
-	
-	
-	if (client->m_sessionStart == std::nullopt) {
-		client->m_sessionStart = timestamp;
-	}
-	else {
-		if(!started){
-			if(first){
-				client->m_sessionStart = timestamp;
-				started = true;
-			}else{
-				client->m_sessionStart = timestamp;
-			}
-		}
-		
+	if (client->m_sessionStart != std::nullopt) {
 		client->m_elapsed = client->m_timestamp - client->m_sessionStart.value();
 	}
 }
@@ -533,6 +515,14 @@ double LivoxClient::getSessionStart()
 		return double(*m_sessionStart)/1e9;
 	}
 	return -1;
+}
+
+void LivoxClient::initializeDuration()
+{
+	std::lock_guard<std::mutex> lcK(m_timestampMutex);
+	if (m_sessionStart == std::nullopt) {
+		m_sessionStart = m_timestamp;
+	}
 }
 
 std::unordered_map<uint32_t, std::string> LivoxClient::getSerialNumberToLidarIdMapping() const

--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -80,10 +80,11 @@ nlohmann::json LivoxClient::produceStatus()
 	std::lock_guard<std::mutex> lcK1(m_bufferLidarMutex);
 	std::lock_guard<std::mutex> lcK2(m_bufferImuMutex);
 	data["LivoxLidarInfo"]["timestamp"] = m_timestamp;
-	if (m_sessionStart) {
-		data["LivoxLidarInfo"]["m_sessionStart"] = *m_sessionStart;
-		data["LivoxLidarInfo"]["m_elapsed"] = m_elapsed;
-	}
+	data["LivoxLidarInfo"]["timestamp_s"] = double(m_timestamp)/1e9;
+	data["LivoxLidarInfo"]["m_sessionStart"] = m_sessionStart.value_or(-1.f);
+	data["LivoxLidarInfo"]["m_sessionStart_s"] = double(m_sessionStart.value_or(-1.f))/1e9;
+	data["LivoxLidarInfo"]["m_elapsed"] = m_elapsed;
+	data["LivoxLidarInfo"]["m_elapsed_s"] = double(m_elapsed)/1e9;
 
 
 	auto arrayworkMode = nlohmann::json::array();

--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <thread>
 
+extern bool first;
+
 namespace mandeye
 {
 
@@ -233,10 +235,24 @@ void LivoxClient::saveTimeStamp(LivoxClient *client, uint64_t timestamp) {
 	assert(client);
 	std::lock_guard<std::mutex> lcK(client->m_timestampMutex);
 	client->m_timestamp = timestamp;
+	
+	static bool started = false;
+	
+	
+	
 	if (client->m_sessionStart == std::nullopt) {
 		client->m_sessionStart = timestamp;
 	}
 	else {
+		if(!started){
+			if(first){
+				client->m_sessionStart = timestamp;
+				started = true;
+			}else{
+				client->m_sessionStart = timestamp;
+			}
+		}
+		
 		client->m_elapsed = client->m_timestamp - client->m_sessionStart.value();
 	}
 }

--- a/code/LivoxClient.h
+++ b/code/LivoxClient.h
@@ -70,7 +70,7 @@ public:
 	double getTimestamp() override;
 	double getSessionDuration() override;
 	double getSessionStart() override;
-
+	void initializeDuration() override;
 	// periodically ask lidars for status
 	void testThread();
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -21,6 +21,7 @@
 #define MANDEYE_GPIO_SIM false
 #define SERVER_PORT 8003
 
+bool first = false;
 
 namespace utils
 {
@@ -157,6 +158,7 @@ std::chrono::steady_clock::time_point stoppingStage2StartDeadlineChangeLed;
 
 bool TriggerContinousScanning(){
 	if(app_state == States::IDLE || app_state == States::STOPPED){
+		first = true;
 		app_state = States::STARTING_SCAN;
 		return true;
 	}else if(app_state == States::SCANNING)

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -21,8 +21,6 @@
 #define MANDEYE_GPIO_SIM false
 #define SERVER_PORT 8003
 
-bool first = false;
-
 namespace utils
 {
 std::string getEnvString(const std::string& env, const std::string& def);
@@ -158,7 +156,12 @@ std::chrono::steady_clock::time_point stoppingStage2StartDeadlineChangeLed;
 
 bool TriggerContinousScanning(){
 	if(app_state == States::IDLE || app_state == States::STOPPED){
-		first = true;
+
+		// intiliaze duration count
+		if (livoxCLientPtr) {
+			livoxCLientPtr->initializeDuration();
+		}
+
 		app_state = States::STARTING_SCAN;
 		return true;
 	}else if(app_state == States::SCANNING)

--- a/code/utils/TimeStampProvider.h
+++ b/code/utils/TimeStampProvider.h
@@ -11,6 +11,9 @@ public:
 	//! Retrieve relative timestamp to start
 	virtual double getSessionDuration() = 0;
 
+	//! Initializes duration count, can be called once
+	virtual void initializeDuration() = 0;
+
 	virtual double getSessionStart() = 0;
 };
 } // namespace mandeye_utils


### PR DESCRIPTION
Duration (dur field in ZMQ) is being counted on press of Continous Scan button.
Added seconds to be more human redable to status json.

Sample status.json:
```
        "LivoxLidarInfo": {
            "dev_type": 9,
            "lidar_ip": "192.168.1.3",
            "m_elapsed": 9568800000,
            "m_elapsed_s": 9.5688,
            "m_sessionStart": 1513106671100,
            "m_sessionStart_s": 1513.1066711,
            "sn": "47MDLA50020005",
            "timestamp": 1522675471100,
            "timestamp_s": 1522.6754711

```
Sample ZMQ message:
Before pressing CS button
```
Received message: {"dur":0,"time":1642912591100}
```
After : 
```
Received message: {"dur":4264319999,"time":1666307791100}

```