### PR TITLE
Due to possible bug in Libcamera od PiCamera2, some parameters cannot…

### DIFF
--- a/extras/picamera2/camera.py
+++ b/extras/picamera2/camera.py
@@ -16,7 +16,7 @@ received_timestamp = 0
 received_mode = ""
 received_command = None
 received_data_continous = ""
-
+Blacklisted = ['FrameDurationLimits']
 def load_json_config(file_path):
     """
     Loads and parses the JSON configuration from the specified file.
@@ -52,7 +52,7 @@ def create_default_config(file_path):
     
     for control, info in controls.items():
         assert(len(info)==3)
-        if type(info[0]) in supported_types or type(info[1]) in supported_types:
+        if type(info[0]) in supported_types or type(info[1]) in supported_types and contol not in Blacklisted:
             data['picamera'][control]=info[2]
             data['picamera_notes'][control]={"min":info[0],"max":info[1], "def":info[2], "type": str(type(info[0])) }
     
@@ -71,7 +71,7 @@ def validate_and_apply_config(config):
 
     for key, value in config.items():
         try:
-            if value is not None:
+            if value is not None and key not in Blacklisted:
                 print (f"Set param {key} to {value}")
                 if key in controls:
                     picam2.set_controls({key: value})
@@ -176,4 +176,5 @@ if __name__ == "__main__":
             print(f"Image saved as {filename}")
         time.sleep(2)
     zmqthread.join()
+
 


### PR DESCRIPTION
… be set

Without that I am getting following error:
```
[0:28:26.610502951] [2529]  WARN IPARPI ipa_base.cpp:775 Could not set AF_MODE - no AF algorithm
[0:28:26.610545766] [2529]  WARN IPARPI ipa_base.cpp:1204 Could not set AF_RANGE - no focus algorithm
python: ../include/libcamera/controls.h:204: T libcamera::ControlValue::get() const [with T = libcamera::Span<const long int>; typename std::enable_if<(libcamera::details::is_span<U>::value || std::is_same<std::__cxx11::basic_string<char>, typename std::remove_cv< <template-parameter-1-1> >::type>::value), std::nullptr_t>::type <anonymous> = nullptr]: Assertion `isArray_' failed.
Aborted
````