### PR TITLE
Fix unit of interwals

### DIFF
--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -282,7 +282,7 @@ void LivoxClient::PointCloudCallback(uint32_t handle,
 			LivoxPoint point;
 			point.point = p_point_data[i];
 			point.laser_id = laser_id;
-			point.timestamp = toUint64.data + i * data->time_interval;
+			point.timestamp = toUint64.data + static_cast<uint64_t>(i) * data->time_interval * 100; //unit for interval is 0.1 us = 100 ns
 			if(point.timestamp > 0){
 				buffer->push_back(point);
 			}


### PR DESCRIPTION
The unit of point interval for livox sdk is one-tenth of microsecond. I've treated it as nanosecs.
You can see a difference in plot of timestamp of point in function of index.
<img width="2831" height="531" alt="Screenshot from 2025-08-26 00-16-39" src="https://github.com/user-attachments/assets/bde04cb5-5a06-4bc2-a249-a261387080ee" />
