### PR TITLE
Correct handling of point interval

### DIFF
--- a/code/LivoxClient.cpp
+++ b/code/LivoxClient.cpp
@@ -282,7 +282,7 @@ void LivoxClient::PointCloudCallback(uint32_t handle,
 			LivoxPoint point;
 			point.point = p_point_data[i];
 			point.laser_id = laser_id;
-			point.timestamp = toUint64.data + static_cast<uint64_t>(i) * data->time_interval * 100; //unit for interval is 0.1 us = 100 ns
+			point.timestamp = toUint64.data + static_cast<uint64_t>(i) * (double(data->time_interval * 100) / data->dot_num); //unit for interval is 0.1 us = 100 ns
 			if(point.timestamp > 0){
 				buffer->push_back(point);
 			}


### PR DESCRIPTION
Ok, now I,ve got it.
Time in time_interval is 0.000475 s. Package contains always 96 points.
Quick math (200 000 points is data rate of Livox)
```math
\frac {96 points }{200 000 {points/second}} = 0.00048 seconds
```

That is very close to that reported by time_interval. So time_interval is interval for 96 points not for one point.
Ok, one more test:
```cpp
	static std::ofstream debugFile ("/home/michal/livox_timestamps.csv");
		for(uint32_t i = 0; i < data->dot_num; i++)
		{
			LivoxPoint point;
			point.point = p_point_data[i];
			point.laser_id = laser_id;
			point.timestamp = toUint64.data + static_cast<uint64_t>(i) * (double(data->time_interval * 100) / data->dot_num); //unit for interval is 0.1 us = 100 ns
			uint64_t p1 = toUint64.data;
			uint64_t p2 = toUint64.data + static_cast<uint64_t>(i) * (double(data->time_interval * 100) / data->dot_num);
			uint64_t p3 = toUint64.data + static_cast<uint64_t>(i) * (double(data->time_interval * 100));

			const auto now = std::chrono::system_clock::now();
			const auto duration = now.time_since_epoch();
			const auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
			uint64_t count =  nanos.count();


			debugFile << p1 << "," << p2 << "," << p3 << "\n";

		}
```
This code will produce CSV:
column 1 - timestamp of the package 
column 2 - treat time_interval as point interval
column 3 - treat time_interval as package interval

So we can clearly see that column 3 provide smooth results:

<img width="1404" height="780" alt="image" src="https://github.com/user-attachments/assets/cde80db9-9ae8-470e-a51f-1e9bcca8fa35" />
[livox_timestamps.csv](https://github.com/user-attachments/files/22586345/livox_timestamps.csv)
